### PR TITLE
Remove position absolute from legend attribute on form input

### DIFF
--- a/app/assets/stylesheets/active_skin.sass
+++ b/app/assets/stylesheets/active_skin.sass
@@ -273,7 +273,6 @@ form fieldset.inputs
   @include rounded(0)
   legend
     border-bottom: 1px solid #d3d8dc
-    position: absolute
     top: 0
     span
       background: #f0f4f5


### PR DESCRIPTION
After update `active-admin` to the last version `2.5.0` we've noticed a bug related to `check_boxes` input:

```ruby
  form do |f|
    f.semantic_errors
    f.inputs do
      ...
      f.input :authorities, as: :check_boxes, multiple: true, collection: resource.authorities
    end
    f.actions
  end
```

Basically, using the last version of `active_skin` from the github master branch, we cannot select the first item:

<img width="1053" alt="Screenshot 2019-12-11 at 10 54 43" src="https://user-images.githubusercontent.com/20430410/70611207-17ec5580-1c05-11ea-95f8-2942b2f879d3.png">

The problem is related to the `legend` position attribute, after remove it, it's working:

<img width="1051" alt="Screenshot 2019-12-11 at 10 55 05" src="https://user-images.githubusercontent.com/20430410/70611226-22a6ea80-1c05-11ea-90a3-9ce22334b028.png">

